### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "miya0001/wp-cli-vhosts",
     "description": "Manage multiple WordPress sites in the server.",
+	"type": "wp-cli-package",
     "homepage": "https://github.com/miya0001/wp-cli-vhosts",
     "license": "GPL-2.0",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
